### PR TITLE
make-index.sh: don't run "git pull" as a part of this script

### DIFF
--- a/make-index.sh
+++ b/make-index.sh
@@ -7,7 +7,6 @@ DIR=$HOME/.cabal/packages/hackage.haskell.org
 TAR=$DIR/00-index.tar
 TARGZ=$TAR.gz
 
-git pull
 mkdir -p "$DIR"
 
 rm -f $TAR $TARGZ


### PR DESCRIPTION
I want to use "make-index.sh" to create a cabal-install database state
from a certain point in time, i.e. a revision I've tagged earlier. This
is impossible if the script updates the current HEAD automatically.
Also, I may want to run the script from branches that have no upstream
configured, in which case the "git pull" command will fail outright.
